### PR TITLE
Update NetworkManager Documentation URL

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -132,7 +132,7 @@ title: Safing Portmaster - Free Download
             <div class="card-influence-bottom-funding">
                 <span class="card-influence-bottom-funding-date">Dependencies</span>
                 <span class="card-influence-bottom-funding-amount">
-                      <a target="_blank" href="https://wiki.gnome.org/Projects/NetworkManager" class="link-primary-external">Network Manager</a>
+                      <a target="_blank" href="https://networkmanager.dev/docs/" class="link-primary-external">Network Manager</a>
                       <span> (Optional)</span>
                       <span tooltip="This is recommended for better integration, but not required."> <i  class="icon-info text-gray-500 ml-1"></i></span>
                 </span>
@@ -164,7 +164,7 @@ title: Safing Portmaster - Free Download
             <div class="card-influence-bottom-funding">
                 <span class="card-influence-bottom-funding-date">Dependencies</span>
                 <span class="card-influence-bottom-funding-amount">
-                    <a target="_blank" href="https://wiki.gnome.org/Projects/NetworkManager" class="link-primary-external">Network Manager</a>
+                    <a target="_blank" href="https://networkmanager.dev/docs/" class="link-primary-external">Network Manager</a>
                     <span> (Optional)</span>
                     <span tooltip="This is recommended for better integration, but not required."> <i  class="icon-info text-gray-500 ml-1"></i></span>
               </span>
@@ -195,7 +195,7 @@ title: Safing Portmaster - Free Download
             <div class="card-influence-bottom-funding">
                 <span class="card-influence-bottom-funding-date">Dependencies</span>
                 <span class="card-influence-bottom-funding-amount">
-                    <a target="_blank" href="https://wiki.gnome.org/Projects/NetworkManager" class="link-primary-external">Network Manager</a>
+                    <a target="_blank" href="https://networkmanager.dev/docs/" class="link-primary-external">Network Manager</a>
                     <span> (Optional)</span>
                     <span tooltip="This is recommended for better integration, but not required."> <i  class="icon-info text-gray-500 ml-1"></i></span>
               </span>
@@ -234,7 +234,7 @@ title: Safing Portmaster - Free Download
             <div class="card-influence-bottom-funding">
                 <span class="card-influence-bottom-funding-date">Dependencies</span>
                 <span class="card-influence-bottom-funding-amount">
-                    <a target="_blank" href="https://wiki.gnome.org/Projects/NetworkManager" class="link-primary-external">Network Manager</a>
+                    <a target="_blank" href="https://networkmanager.dev/docs/" class="link-primary-external">Network Manager</a>
                     <span> (Optional)</span>
                     <span tooltip="This is recommended for better integration, but not required."> <i  class="icon-info text-gray-500 ml-1"></i></span>
               </span>
@@ -306,7 +306,7 @@ title: Safing Portmaster - Free Download
             <div class="card-influence-bottom-funding">
                 <span class="card-influence-bottom-funding-date">Dependencies</span>
                 <span class="card-influence-bottom-funding-amount">
-                      <a target="_blank" href="https://wiki.gnome.org/Projects/NetworkManager" class="link-primary-external">Network Manager</a>
+                      <a target="_blank" href="https://networkmanager.dev/docs/" class="link-primary-external">Network Manager</a>
                       <span> (Optional)</span>
                       <span tooltip="This is recommended for better integration, but not required."> <i  class="icon-info text-gray-500 ml-1"></i></span>
                 </span>
@@ -338,7 +338,7 @@ title: Safing Portmaster - Free Download
             <div class="card-influence-bottom-funding">
                 <span class="card-influence-bottom-funding-date">Dependencies</span>
                 <span class="card-influence-bottom-funding-amount">
-                    <a target="_blank" href="https://wiki.gnome.org/Projects/NetworkManager" class="link-primary-external">Network Manager</a>
+                    <a target="_blank" href="https://networkmanager.dev/docs/" class="link-primary-external">Network Manager</a>
                     <span> (Optional)</span>
                     <span tooltip="This is recommended for better integration, but not required."> <i  class="icon-info text-gray-500 ml-1"></i></span>
               </span>
@@ -369,7 +369,7 @@ title: Safing Portmaster - Free Download
             <div class="card-influence-bottom-funding">
                 <span class="card-influence-bottom-funding-date">Dependencies</span>
                 <span class="card-influence-bottom-funding-amount">
-                    <a target="_blank" href="https://wiki.gnome.org/Projects/NetworkManager" class="link-primary-external">Network Manager</a>
+                    <a target="_blank" href="https://networkmanager.dev/docs/" class="link-primary-external">Network Manager</a>
                     <span> (Optional)</span>
                     <span tooltip="This is recommended for better integration, but not required."> <i  class="icon-info text-gray-500 ml-1"></i></span>
               </span>
@@ -408,7 +408,7 @@ title: Safing Portmaster - Free Download
             <div class="card-influence-bottom-funding">
                 <span class="card-influence-bottom-funding-date">Dependencies</span>
                 <span class="card-influence-bottom-funding-amount">
-                    <a target="_blank" href="https://wiki.gnome.org/Projects/NetworkManager" class="link-primary-external">Network Manager</a>
+                    <a target="_blank" href="https://networkmanager.dev/docs/" class="link-primary-external">Network Manager</a>
                     <span> (Optional)</span>
                     <span tooltip="This is recommended for better integration, but not required."> <i  class="icon-info text-gray-500 ml-1"></i></span>
               </span>


### PR DESCRIPTION
The existing download page lists NetworkManager as an optional dependency for linux, linking to Gnome Wiki's NetworkManager page.

The Gnome Wiki has been retired, and explicitly states that information is out of date.

NetworkManager maintains their own site which includes the man pages, tutorials, and more.

This commit replaces all Gnome Wiki urls with the networkmanager[dot]dev url.

Fixes #298 